### PR TITLE
Fix for exception when trying to dismiss WaitingMenu.

### DIFF
--- a/BeatSaberOnline/Controllers/GameController.cs
+++ b/BeatSaberOnline/Controllers/GameController.cs
@@ -49,14 +49,14 @@ namespace BeatSaberOnline.Controllers
         }
         private ResultsViewController _resultsViewController;
         private string _currentScene;
-
+        
         public static void Init(Scene to)
         {
             if (Instance != null)
             {
                 return;
             }
-
+            
             new GameObject("InGameOnlineController").AddComponent<GameController>();
         }
 
@@ -72,7 +72,7 @@ namespace BeatSaberOnline.Controllers
                 _currentScene = SceneManager.GetActiveScene().name;
             }
         }
-
+        
 
         IEnumerator RunLobbyCleanup()
         {
@@ -114,7 +114,7 @@ namespace BeatSaberOnline.Controllers
                 }
             }
         }
-
+       
         public void ActiveSceneChanged(Scene from, Scene to)
         {
             try
@@ -169,7 +169,7 @@ namespace BeatSaberOnline.Controllers
             }
             return null;
         }
-
+        
         public void SongFinished(StandardLevelSceneSetupDataSO sender, LevelCompletionResults levelCompletionResults, IDifficultyBeatmap difficultyBeatmap, GameplayModifiers gameplayModifiers)
         {
             try

--- a/BeatSaberOnline/Controllers/GameController.cs
+++ b/BeatSaberOnline/Controllers/GameController.cs
@@ -49,14 +49,14 @@ namespace BeatSaberOnline.Controllers
         }
         private ResultsViewController _resultsViewController;
         private string _currentScene;
-        
+
         public static void Init(Scene to)
         {
             if (Instance != null)
             {
                 return;
             }
-            
+
             new GameObject("InGameOnlineController").AddComponent<GameController>();
         }
 
@@ -72,13 +72,19 @@ namespace BeatSaberOnline.Controllers
                 _currentScene = SceneManager.GetActiveScene().name;
             }
         }
-        
+
 
         IEnumerator RunLobbyCleanup()
         {
             yield return new WaitUntil(delegate () { return WaitingMenu.Instance.isActiveAndEnabled; });
             Logger.Debug("Finished song, doing cleanup");
-            WaitingMenu.Instance.Dismiss();
+            try
+            {
+                WaitingMenu.Instance.Dismiss();
+            } catch (Exception e)
+            {
+                Logger.Error($"Error dismissing WaitingMenu {e}");
+            }
             WaitingMenu.firstInit = true;
             WaitingMenu.queuedSong = null;
             WaitingMenu.autoReady = false;
@@ -108,8 +114,8 @@ namespace BeatSaberOnline.Controllers
                 }
             }
         }
-       
-            public void ActiveSceneChanged(Scene from, Scene to)
+
+        public void ActiveSceneChanged(Scene from, Scene to)
         {
             try
             {
@@ -163,7 +169,7 @@ namespace BeatSaberOnline.Controllers
             }
             return null;
         }
-        
+
         public void SongFinished(StandardLevelSceneSetupDataSO sender, LevelCompletionResults levelCompletionResults, IDifficultyBeatmap difficultyBeatmap, GameplayModifiers gameplayModifiers)
         {
             try

--- a/BeatSaberOnline/Views/PluginUI.cs
+++ b/BeatSaberOnline/Views/PluginUI.cs
@@ -69,8 +69,13 @@ namespace BeatSaberOnline.Views
                 {
                     SteamAPI.CreateLobby(!Config.Instance.IsPublic);
                 }
-
-                AvatarController.LoadAvatars();
+                try
+                {
+                    AvatarController.LoadAvatars();
+                } catch (Exception e)
+                {
+                    Logger.Error($"Unable to load avatars! Exception: {e}");
+                }
                 SongListUtils.Initialize();
                 MultiplayerListing.Init();
                 MultiplayerLobby.Init();


### PR DESCRIPTION
Sometimes after ending a song WaitingMenu.Instance.Dismiss() would throw an exception, breaking the rest of RunLobbyCleanup(). Seems to only affect the host, and puts them in a state where they can't start a song because _playerInfo.InSong is never set to false. Simply catching the exception seems to fix it and doesn't cause more exceptions after that. You might want to look into why it's doing that in the first place.